### PR TITLE
fix: add smart entry point to resolve restart loop issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,7 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD curl -f http://localhost:8000/health/simple || exit 1
 
-# Run the refactored application
-CMD ["python", "-m", "src.app"]
+# Run the application with smart entry point that selects mode based on RUN_MODE
+# RUN_MODE=service: Uses persistent service mode (prevents restart loops)
+# RUN_MODE=oneshot: Uses traditional oneshot mode (default for backward compatibility)
+CMD ["python", "-m", "src.main"]

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for running the match list processor as a module."""
+
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Smart entry point for match list processor.
+
+This module automatically selects the appropriate application mode based on the RUN_MODE environment variable:
+- RUN_MODE=service: Uses persistent service mode (src.app_persistent)
+- RUN_MODE=oneshot: Uses traditional oneshot mode (src.app)
+- Default: oneshot mode for backward compatibility
+
+This resolves the restart loop issue by ensuring the correct application mode is used
+based on deployment configuration.
+"""
+
+import logging
+import os
+import sys
+
+# Set up basic logging for the entry point
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Main entry point that selects the appropriate application mode."""
+    run_mode = os.environ.get("RUN_MODE", "oneshot").lower()
+
+    logger.info(f"Match List Processor starting in {run_mode} mode...")
+
+    if run_mode == "service":
+        logger.info("Using persistent service mode (src.app_persistent)")
+        try:
+            from src.app_persistent import main as persistent_main
+
+            persistent_main()
+        except ImportError as e:
+            logger.error(f"Failed to import persistent service module: {e}")
+            logger.error("Falling back to oneshot mode")
+            run_mode = "oneshot"
+
+    if run_mode == "oneshot":
+        logger.info("Using oneshot mode (src.app)")
+        try:
+            from src.app import main as oneshot_main
+
+            oneshot_main()
+        except ImportError as e:
+            logger.error(f"Failed to import oneshot module: {e}")
+            sys.exit(1)
+
+    if run_mode not in ["service", "oneshot"]:
+        logger.warning(f"Unknown RUN_MODE '{run_mode}', defaulting to oneshot mode")
+        from src.app import main as oneshot_main
+
+        oneshot_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main_entry_point.py
+++ b/tests/test_main_entry_point.py
@@ -1,0 +1,100 @@
+"""Tests for the smart entry point module."""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# Add src to path for testing
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from src.main import main  # noqa: E402
+
+
+class TestMainEntryPoint:
+    """Test cases for the smart entry point functionality."""
+
+    @patch("src.main.logger")
+    @patch("src.app.main")
+    def test_default_mode_oneshot(self, mock_oneshot_main, mock_logger):
+        """Test that default mode uses oneshot application."""
+        # Remove RUN_MODE from environment
+        with patch.dict(os.environ, {}, clear=True):
+            main()
+
+        mock_logger.info.assert_any_call("Match List Processor starting in oneshot mode...")
+        mock_logger.info.assert_any_call("Using oneshot mode (src.app)")
+        mock_oneshot_main.assert_called_once()
+
+    @patch("src.main.logger")
+    @patch("src.app_persistent.main")
+    def test_service_mode(self, mock_persistent_main, mock_logger):
+        """Test that service mode uses persistent application."""
+        with patch.dict(os.environ, {"RUN_MODE": "service"}):
+            main()
+
+        mock_logger.info.assert_any_call("Match List Processor starting in service mode...")
+        mock_logger.info.assert_any_call("Using persistent service mode (src.app_persistent)")
+        mock_persistent_main.assert_called_once()
+
+    @patch("src.main.logger")
+    @patch("src.app.main")
+    def test_explicit_oneshot_mode(self, mock_oneshot_main, mock_logger):
+        """Test that explicit oneshot mode works correctly."""
+        with patch.dict(os.environ, {"RUN_MODE": "oneshot"}):
+            main()
+
+        mock_logger.info.assert_any_call("Match List Processor starting in oneshot mode...")
+        mock_logger.info.assert_any_call("Using oneshot mode (src.app)")
+        mock_oneshot_main.assert_called_once()
+
+    @patch("src.main.logger")
+    @patch("src.app.main")
+    def test_unknown_mode_defaults_to_oneshot(self, mock_oneshot_main, mock_logger):
+        """Test that unknown RUN_MODE defaults to oneshot."""
+        with patch.dict(os.environ, {"RUN_MODE": "unknown"}):
+            main()
+
+        mock_logger.warning.assert_any_call(
+            "Unknown RUN_MODE 'unknown', defaulting to oneshot mode"
+        )
+        mock_oneshot_main.assert_called_once()
+
+    @patch("src.main.logger")
+    @patch("src.app.main", side_effect=ImportError("Test import error"))
+    def test_oneshot_import_error_exits(self, mock_oneshot_main, mock_logger):
+        """Test that import error in oneshot mode causes exit."""
+        with patch.dict(os.environ, {"RUN_MODE": "oneshot"}):
+            with pytest.raises(SystemExit):
+                main()
+
+        mock_logger.error.assert_any_call("Failed to import oneshot module: Test import error")
+
+    @patch("src.main.logger")
+    @patch("src.app_persistent.main", side_effect=ImportError("Test persistent import error"))
+    @patch("src.app.main")
+    def test_persistent_import_error_falls_back_to_oneshot(
+        self, mock_oneshot_main, mock_persistent_main, mock_logger
+    ):
+        """Test that import error in persistent mode falls back to oneshot."""
+        with patch.dict(os.environ, {"RUN_MODE": "service"}):
+            main()
+
+        mock_logger.error.assert_any_call(
+            "Failed to import persistent service module: Test persistent import error"
+        )
+        mock_logger.error.assert_any_call("Falling back to oneshot mode")
+        mock_oneshot_main.assert_called_once()
+
+    @patch("src.main.logger")
+    @patch("src.app.main")
+    def test_case_insensitive_mode(self, mock_oneshot_main, mock_logger):
+        """Test that RUN_MODE is case insensitive."""
+        with patch.dict(os.environ, {"RUN_MODE": "SERVICE"}):
+            # Mock the persistent import to test the case conversion
+            with patch("src.app_persistent.main") as mock_persistent_main:
+                main()
+
+            mock_logger.info.assert_any_call("Match List Processor starting in service mode...")
+            mock_persistent_main.assert_called_once()


### PR DESCRIPTION
## Problem

The match-list-processor service was experiencing a restart loop issue in deployment environments when configured with `RUN_MODE=service`. This occurred because:

1. The Dockerfile had a hardcoded entry point: `CMD ["python", "-m", "src.app"]`
2. The `src.app` module only supports oneshot mode and exits after processing
3. Docker's `restart: unless-stopped` policy caused continuous restarts
4. The `RUN_MODE=service` environment variable was ignored

## Root Cause Analysis

Our analysis revealed that while the persistent service implementation (`src.app_persistent`) was correctly implemented in commit f5d399a, the container entry point was still hardcoded to use the oneshot version. This created a configuration mismatch where:

- Environment variables indicated service mode: `RUN_MODE=service`
- Container always executed oneshot mode: `python -m src.app`
- Result: Service completed processing and exited, triggering restart loop

## Solution

This PR implements a **smart entry point** that automatically selects the appropriate application mode based on the `RUN_MODE` environment variable:

### Changes Made

1. **Smart Entry Point** (`src/main.py`):
   - Reads `RUN_MODE` environment variable
   - `RUN_MODE=service` → Uses `src.app_persistent` (persistent service mode)
   - `RUN_MODE=oneshot` → Uses `src.app` (traditional oneshot mode)
   - Default → oneshot mode (backward compatibility)
   - Includes fallback logic and error handling

2. **Updated Dockerfile**:
   - Changed from: `CMD ["python", "-m", "src.app"]`
   - Changed to: `CMD ["python", "-m", "src.main"]`
   - Added clear comments explaining the behavior

3. **Module Support** (`src/__main__.py`):
   - Enables `python -m src` execution
   - Delegates to smart entry point

4. **Comprehensive Tests** (`tests/test_main_entry_point.py`):
   - Tests all RUN_MODE scenarios
   - Tests fallback behavior
   - Tests error handling
   - Ensures backward compatibility

### Benefits

- ✅ **Resolves restart loop**: Service mode now runs persistently
- ✅ **Backward compatible**: Existing deployments continue to work
- ✅ **Environment-driven**: Behavior controlled by `RUN_MODE` variable
- ✅ **Error resilient**: Graceful fallbacks and clear error messages
- ✅ **Well tested**: Comprehensive test coverage for all scenarios

## Testing

- All existing tests pass
- New tests cover smart entry point functionality
- Manual testing confirms restart loop resolution
- Verified in deployment environment

## Related Issues

This PR addresses the restart loop issue identified during FOGIS deployment migration testing. It works in conjunction with deployment configuration updates to ensure stable service operation.

## Deployment Impact

- **Immediate**: Can be deployed with current deployment configurations
- **Future**: New container images will automatically use correct entry point
- **Rollback**: Safe to rollback - maintains backward compatibility

---

**Cross-reference**: This PR works with deployment configuration updates in the fogis-deployment repository to provide a complete solution for the restart loop issue.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author