### PR TITLE
ci: Add Docker publish workflow for main branch pushes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,67 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [ main, develop ]
+  workflow_dispatch:  # Allow manual triggering
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: pitchconnect/match-list-processor
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine build platforms
+        id: platforms
+        run: |
+          # Build multi-platform for main branch
+          # Develop branch uses AMD64 only for faster CI/CD
+          if [[ "${{ github.ref }}" == refs/heads/main ]]; then
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+            echo "Building multi-platform (AMD64 + ARM64) for main branch"
+          else
+            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+            echo "Building AMD64 only for faster CI/CD (develop)"
+          fi
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: ${{ steps.platforms.outputs.platforms }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.sha }}


### PR DESCRIPTION
## Summary

Add new workflow to publish Docker images to GHCR on main branch pushes. This ensures that the latest code on main is always available as multi-platform (AMD64 + ARM64) images in GHCR.

## Changes

- Created new `.github/workflows/docker-publish.yml` workflow
- Builds and publishes on main and develop branch pushes
- Main branch builds both AMD64 and ARM64 platforms
- Develop branch builds AMD64 only for faster CI/CD
- Separate from `release.yml` which handles tagged releases

## Rationale

1. **Production Readiness**: Main branch should always have production-ready, multi-platform images
2. **Deployment Enablement**: Enables deployment on ARM64 systems without requiring tagged releases
3. **Complements Existing Workflow**: Works alongside `release.yml` for tagged releases
4. **Best Practices**: Aligns with container image distribution best practices
5. **Current Issue**: Latest commits on main (including Redis pub/sub fixes and referee field typo fix) are not available as images, blocking deployment

## Impact

- **Build Time**: Main branch builds will take ~5-7 minutes for multi-platform build
- **Image Availability**: All main branch commits will be immediately available for deployment
- **CI/CD Speed**: Develop branch builds remain fast (AMD64-only)
- **Existing Workflows**: No changes to existing `ci.yml` or `release.yml` workflows

## Testing

- Workflow syntax validated
- Logic tested with conditional expressions
- Uses same Docker build process as `release.yml`

## Related

- Deployment analysis: COMPREHENSIVE_DEPLOYMENT_ANALYSIS.md
- Issue: GHCR images are 7 days outdated, missing critical Redis fixes
- Blocks: System deployment with latest features

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author